### PR TITLE
Skip creating faces that already exists

### DIFF
--- a/s3o_import.py
+++ b/s3o_import.py
@@ -290,7 +290,10 @@ class s3o_piece(object):
                 bm.verts.ensure_lookup_table()
                 bm.verts[-1].normal = Vector((v.xnormal, v.ynormal, v.znormal))
             for f in self.faces:
-                bm.faces.new([bm.verts[self.vertids[i]] for i in f])
+                try:
+                    bm.faces.new([bm.verts[self.vertids[i]] for i in f])
+                except ValueError:
+                    pass
                 bm.faces.ensure_lookup_table()
                 uv_layer = bm.loops.layers.uv.verify()
                 for i, loop in enumerate(bm.faces[-1].loops):


### PR DESCRIPTION
while I am sending you PRs

I don't know how this should actually be handled
but was previously getting this error

```
File "s3o_import.py", line 293, in load
    bm.faces.new([bm.verts[self.vertids[i]] for i in f])
ValueError: faces.new(verts): face already exists
```

when trying to import https://github.com/ZeroK-RTS/Zero-K/blob/master/Objects3d/commsupport.s3o