### PR TITLE
* Fixed bug with animation curves with no location keys being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.idea/workspace.xml
+*.xml


### PR DESCRIPTION
* BOS and LUS output now works properly when no position keys are present in an animation curve
* Added 'OMITDELTAOUTPUT' outer scope variable (not exposed to the interface, defaults to False), to hide the delta comments from the output