### PR TITLE
Added 'LUS Tween' Export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Usage:
 
 https://www.youtube.com/watch?v=gH5uATTTYB4
 
-7. Export to BOS, LUS (Lua Unit Script) or [LUS Tween format](https://github.com/FluidPlay/TAP/blob/main/scripts/include/springtweener.lua) by clicking the bottom buttons. The script will be created right next to where the current blender files is saved.
+7. Export to BOS, LUS (Lua Unit Script) or [LUS Tween format](https://github.com/FluidPlay/TAP/blob/main/scripts/include/springtweener.lua) by clicking the bottom buttons. The script will be created right next to where the current blender file is saved.
 
 8. Enjoy!
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,21 @@ Usage:
 
 1. Register the script with blender 2.80+ 
 
-2. Go into object mode and select the root piece (pelvis/base) of the model
+2. Select the collection where the root piece (pelvis/base) of the model is. Make sure it's within a collection.
 
-3. Press the "Create Skeleton" button
+3. Hit Tab, type "Apply Rotation", and select Object > Apply > Rotation & Scale
 
-4. You can now go into Pose mode and flail the appendages around. 
+4. Press the "Create Skeleton" button
 
-5. If inverse kinematics is somehow not perfectly set up automagically, I recommend watching this video, in 5 minutes it will explain things better than I ever could.
+5. You can now go into Pose mode and flail the appendages around. 
+
+6. If you keep enabled "Add IK targets to chains", the addon will setup up inverse kinematics automagically for you, so you can rotate chains from a controller at its tip. If that fails for some reason, I recommend watching this video, in 5 minutes it will explain things better than I ever could:
 
 https://www.youtube.com/watch?v=gH5uATTTYB4
 
-6. Export to BOS.
+7. Export to BOS, LUS (Lua Unit Script) or [LUS Tween format](https://github.com/FluidPlay/TAP/blob/main/scripts/include/springtweener.lua) by clicking the bottom buttons. The script will be created right next to where the current blender files is saved.
+
+8. Enjoy!
 
 
 ![example](cormort.gif)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Usage:
 https://www.youtube.com/watch?v=gH5uATTTYB4
 
 7. Export to BOS, LUS (Lua Unit Script) or [LUS Tween format](https://github.com/FluidPlay/TAP/blob/main/scripts/include/springtweener.lua) by clicking the bottom buttons. The script will be created right next to where the current blender file is saved.
+   - For videos showcasing the entire production workflow from a blender model, to animating it, exporting and integrating it in SpringRTS (with the SpringTweener library), check the three videos which start here: https://www.youtube.com/watch?v=W1U3WAbjXss
 
 8. Enjoy!
 


### PR DESCRIPTION
I also added links to the video tutorials I did on how to animate in Blender with Skeletor (for Tweening) and integrating with SpringTweener. It's now fully tested and stable. Before merge it's probably worth a quick test with the original (non-tweening) options to see if I didn't break anything there, since I didn't test them.