### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A blender script that automatically generates a skeleton for an s3o imported mod
 
 Usage:
 
-1. Register the script with blender 2.80+ 
+1. Register the script with any version of blender from 2.80 up to 4.3 LTS
 
 2. Select the collection where the root piece (pelvis/base) of the model is. Make sure it's within a collection.
 


### PR DESCRIPTION
I went through version 3.6 until 4.4 of Blender through Steam betas and loaded up an animation blend, then tried to create a bos each time. 4.4 LTS confirmed does not work with Skeletor. I think for people that use Steam auto-update this is important to mention.

Note: The version of blender that has the old (and better) modifiers menu is 3.6 LTS, and some people would prefer much more to work on that version.